### PR TITLE
Factor the derive typenum ident and allow-tables emission into helpers

### DIFF
--- a/diesel-builders-derive/src/descendant.rs
+++ b/diesel-builders-derive/src/descendant.rs
@@ -12,7 +12,7 @@ pub fn generate_auxiliary_descendant_impls(table_type: &Type, ancestors: &[Type]
     let num_ancestors = ancestors.len();
 
     // Generate TupleIndex for self (last position in ancestors + self)
-    let self_idx = syn::Ident::new(&format!("U{num_ancestors}"), proc_macro2::Span::call_site());
+    let self_idx = crate::utils::typenum_ident(num_ancestors);
 
     // Generate DescendantOf implementations for each direct ancestor
     let descendant_of_impls: Vec<_> = ancestors
@@ -29,7 +29,7 @@ pub fn generate_auxiliary_descendant_impls(table_type: &Type, ancestors: &[Type]
         .iter()
         .enumerate()
         .map(|(i, ancestor)| {
-            let idx = syn::Ident::new(&format!("U{i}"), proc_macro2::Span::call_site());
+            let idx = crate::utils::typenum_ident(i);
             quote! {
                 impl diesel_builders::AncestorOfIndex<#table_type> for #ancestor {
                     type Idx = diesel_builders::typenum::#idx;

--- a/diesel-builders-derive/src/lib.rs
+++ b/diesel-builders-derive/src/lib.rs
@@ -54,7 +54,7 @@ fn generate_index_impl(input: TokenStream, trait_path: &proc_macro2::TokenStream
     let cols: Vec<_> = index_def.columns.iter().collect();
 
     let impls = cols.iter().enumerate().map(|(idx, col)| {
-        let idx_type = syn::Ident::new(&format!("U{idx}"), proc_macro2::Span::call_site());
+        let idx_type = crate::utils::typenum_ident(idx);
         quote::quote! {
             impl #trait_path<
                 diesel_builders::typenum::#idx_type,

--- a/diesel-builders-derive/src/table_model.rs
+++ b/diesel-builders-derive/src/table_model.rs
@@ -191,7 +191,7 @@ fn same_as_index_impls(
         .iter()
         .enumerate()
         .map(|(index, column)| {
-            let idx = syn::Ident::new(&format!("U{index}"), proc_macro2::Span::call_site());
+            let idx = crate::utils::typenum_ident(index);
             quote! {
                 impl ::diesel_builders::#same_as_trait for #column {
                     type Idx = ::diesel_builders::typenum::#idx;
@@ -505,13 +505,7 @@ pub fn derive_table_model_impl(input: &DeriveInput) -> syn::Result<TokenStream> 
     let allow_same_query_calls = allow_same_query_pairs
         .into_iter()
         .filter_map(|(first, second)| {
-            if crate::utils::should_generate_allow_tables_to_appear_in_same_query(first, second) {
-                Some(quote! {
-                    ::diesel::allow_tables_to_appear_in_same_query!(#first, #second);
-                })
-            } else {
-                None
-            }
+            crate::utils::allow_tables_to_appear_in_same_query(first, second)
         })
         .collect::<Vec<_>>();
 
@@ -812,7 +806,7 @@ pub fn derive_table_model_impl(input: &DeriveInput) -> syn::Result<TokenStream> 
             }
 
             let idx_type = if let Some(i) = idx {
-                let idx_ident = syn::Ident::new(&format!("U{i}"), proc_macro2::Span::call_site());
+                let idx_ident = crate::utils::typenum_ident(i);
                 quote! { ::diesel_builders::typenum::#idx_ident }
             } else {
                 quote! { ::diesel_builders::typenum::U0 }

--- a/diesel-builders-derive/src/table_model/foreign_keys.rs
+++ b/diesel-builders-derive/src/table_model/foreign_keys.rs
@@ -111,13 +111,11 @@ pub fn generate_foreign_key_impls(
                             crate::utils::extract_table_path_from_column(&ref_col)
                         {
                             let host_table: syn::Path = syn::parse_quote!(#table_module);
-                            if crate::utils::should_generate_allow_tables_to_appear_in_same_query(
+                            if let Some(stream) = crate::utils::allow_tables_to_appear_in_same_query(
                                 &host_table,
                                 &ref_table,
                             ) {
-                                impls.push(quote! {
-                                    ::diesel::allow_tables_to_appear_in_same_query!(#host_table, #ref_table);
-                                });
+                                impls.push(stream);
                             }
                         }
 
@@ -202,14 +200,10 @@ pub fn generate_explicit_foreign_key_impls(
         // Try extract table from first ref col for allow_same_query
         if let Some(first_ref) = ref_cols.first()
             && let Some(ref_table) = crate::utils::extract_table_path_from_column(first_ref)
-            && crate::utils::should_generate_allow_tables_to_appear_in_same_query(
-                &host_table_path,
-                &ref_table,
-            )
+            && let Some(stream) =
+                crate::utils::allow_tables_to_appear_in_same_query(&host_table_path, &ref_table)
         {
-            impls.push(
-                quote! { ::diesel::allow_tables_to_appear_in_same_query!(#table_module, #ref_table); },
-            );
+            impls.push(stream);
         }
 
         // If this is a single column FK that will become an FPK, skip
@@ -224,7 +218,7 @@ pub fn generate_explicit_foreign_key_impls(
             fk.host_columns.iter().map(|c| quote!(#table_module::#c)).collect();
 
         for (idx, host_col_ident) in fk.host_columns.iter().enumerate() {
-            let idx_type = syn::Ident::new(&format!("U{idx}"), proc_macro2::Span::call_site());
+            let idx_type = crate::utils::typenum_ident(idx);
             let host_col = quote!(#table_module::#host_col_ident);
             impls.push(quote! {
                 impl ::diesel_builders::HostColumn<
@@ -240,13 +234,10 @@ pub fn generate_explicit_foreign_key_impls(
     for (_, (host_col_ident, tables)) in host_col_to_refs {
         if tables.len() == 1 {
             let ref_table = &tables[0];
-            if crate::utils::should_generate_allow_tables_to_appear_in_same_query(
-                &host_table_path,
-                ref_table,
-            ) {
-                impls.push(
-                    quote! { ::diesel::allow_tables_to_appear_in_same_query!(#table_module, #ref_table); },
-                );
+            if let Some(stream) =
+                crate::utils::allow_tables_to_appear_in_same_query(&host_table_path, ref_table)
+            {
+                impls.push(stream);
             }
 
             if let Some(stream) =

--- a/diesel-builders-derive/src/table_model/may_get_columns.rs
+++ b/diesel-builders-derive/src/table_model/may_get_columns.rs
@@ -7,7 +7,7 @@ pub fn generate_may_get_column_impls(
     table_module: &syn::Ident,
 ) -> proc_macro2::TokenStream {
     new_record_columns.iter().enumerate().map(|(idx, new_record_column)| {
-		let typenum_index = syn::Ident::new(&format!("U{idx}"), proc_macro2::Span::call_site());
+		let typenum_index = crate::utils::typenum_ident(idx);
 		let index_path = quote::quote! {
 			::diesel_builders::typenum::#typenum_index
 		};

--- a/diesel-builders-derive/src/table_model/primary_key.rs
+++ b/diesel-builders-derive/src/table_model/primary_key.rs
@@ -16,7 +16,7 @@ pub fn generate_indexed_column_impls(
         .iter()
         .enumerate()
         .map(|(idx, col)| {
-            let idx_type = syn::Ident::new(&format!("U{idx}"), proc_macro2::Span::call_site());
+            let idx_type = crate::utils::typenum_ident(idx);
             quote! {
                 impl ::diesel_builders::UniquelyIndexedColumn<
                     ::diesel_builders::typenum::#idx_type,

--- a/diesel-builders-derive/src/table_model/set_columns.rs
+++ b/diesel-builders-derive/src/table_model/set_columns.rs
@@ -7,7 +7,7 @@ pub(super) fn generate_set_column_impls(
     table_module: &syn::Ident,
 ) -> proc_macro2::TokenStream {
     new_record_columns.iter().enumerate().map(|(idx, new_record_column)| {
-		let typenum_index = syn::Ident::new(&format!("U{idx}"), proc_macro2::Span::call_site());
+		let typenum_index = crate::utils::typenum_ident(idx);
 		let index_path = quote::quote! {
 			::diesel_builders::typenum::#typenum_index
 		};

--- a/diesel-builders-derive/src/utils.rs
+++ b/diesel-builders-derive/src/utils.rs
@@ -8,6 +8,11 @@ use std::{
 
 use quote::ToTokens;
 
+/// Builds the `typenum` unsigned marker identifier `U{index}` such as `U0`.
+pub(crate) fn typenum_ident(index: usize) -> syn::Ident {
+    syn::Ident::new(&format!("U{index}"), proc_macro2::Span::call_site())
+}
+
 /// Static lookup struct to track which table pairs have already had
 /// `diesel::allow_tables_to_appear_in_same_query!` generated.
 /// This prevents duplicate macro invocations which would cause compile errors.
@@ -86,10 +91,7 @@ pub(crate) fn camel_to_snake_case(s: &str) -> String {
 ///
 /// Returns `true` if this pair hasn't been generated yet.
 /// Uses a static lookup struct to track pairs.
-pub(crate) fn should_generate_allow_tables_to_appear_in_same_query(
-    t1: &syn::Path,
-    t2: &syn::Path,
-) -> bool {
+fn should_generate_allow_tables_to_appear_in_same_query(t1: &syn::Path, t2: &syn::Path) -> bool {
     // Initialize the static map if needed
     let map = GENERATED_LINKS.get_or_init(|| Mutex::new(HashSet::new()));
 
@@ -116,6 +118,23 @@ pub(crate) fn should_generate_allow_tables_to_appear_in_same_query(
 
     let mut lock = map.lock().unwrap();
     lock.insert(hash)
+}
+
+/// Emits a `diesel::allow_tables_to_appear_in_same_query!` invocation for the
+/// pair of tables, or `None` when the pair has already been generated.
+///
+/// Wraps `should_generate_allow_tables_to_appear_in_same_query` so callers
+/// declare a joinable pair in one expression instead of repeating the guard and
+/// the macro call.
+pub(crate) fn allow_tables_to_appear_in_same_query(
+    t1: &syn::Path,
+    t2: &syn::Path,
+) -> Option<proc_macro2::TokenStream> {
+    should_generate_allow_tables_to_appear_in_same_query(t1, t2).then(|| {
+        quote::quote! {
+            ::diesel::allow_tables_to_appear_in_same_query!(#t1, #t2);
+        }
+    })
 }
 
 /// Extracts the table path from a column path.


### PR DESCRIPTION
The derive crate built the typenum Uxx marker through the same syn::Ident::new call with a call-site span in nine places, and it declared a joinable table pair by repeating a should-generate guard around a diesel::allow_tables_to_appear_in_same_query invocation in four places.

This change adds two small helpers to the derive utils. One builds the Uxx marker from an index, and one wraps the deduplication guard so it returns the ready-to-push macro invocation as an Option, or nothing when the pair was already emitted, which lets each caller declare a pair in a single expression. The guard that backs it is now private since the wrapper is its only user.

The generated code is unchanged. The two call sites that spelled the host table as the table module identifier now pass the equivalent host-table path, which tokenizes identically. Build, clippy, the doctests, the trybuild cases and the coverage build all pass.

## Summary by Sourcery

Refactor derive code generation to use shared helpers for typenum identifiers and deduplicated table-pair declarations.

Enhancements:
- Centralize typenum marker identifier generation and joinable-table macro emission in derive utilities.
- Simplify derive call sites while preserving generated code and deduplicating table-pair declarations consistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Repeated `typenum::Uxx` identifier construction and allow tables guards made the derive code harder to maintain and allowed deduplication logic to remain distributed. The new `crate::utils` helpers centralize these operations and keep the guard implementation private.

All call sites now use the shared helpers. Equivalent host table paths are normalized at two call sites, while generated code remains unchanged. Build, clippy, doctests, trybuild cases, and the coverage build pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->