### PR TITLE
Fix latent nits from the duplication survey

### DIFF
--- a/diesel-builders-derive/src/table_model.rs
+++ b/diesel-builders-derive/src/table_model.rs
@@ -390,17 +390,21 @@ pub fn derive_table_model_impl(input: &DeriveInput) -> syn::Result<TokenStream> 
                 if let Some(pk_field) = pk_field {
                     let same_as_cols_groups = extract_same_as_columns(pk_field)?;
 
-                    let has_same_as_to_mandatory =
-                        same_as_cols_groups.iter().flatten().any(|path| {
-                            let number_of_segments = path.segments.len();
-                            assert!(
-                                number_of_segments >= 2,
-                                "Column path in #[same_as(...)] must be in the format `table::column`"
-                            );
-                            let col_table = &path.segments[number_of_segments - 2];
-                            let mandatory_table = &mandatory_table.segments.last().unwrap();
-                            col_table.ident == mandatory_table.ident
-                        });
+                    let mandatory_table_ident = &mandatory_table.segments.last().unwrap().ident;
+                    let mut has_same_as_to_mandatory = false;
+                    for path in same_as_cols_groups.iter().flatten() {
+                        let number_of_segments = path.segments.len();
+                        if number_of_segments < 2 {
+                            return Err(syn::Error::new_spanned(
+                                path,
+                                "Column path in `#[same_as(...)]` must be in the format `table::column`",
+                            ));
+                        }
+                        if path.segments[number_of_segments - 2].ident == *mandatory_table_ident {
+                            has_same_as_to_mandatory = true;
+                            break;
+                        }
+                    }
 
                     if !has_same_as_to_mandatory {
                         let mandatory_table_str = tokens_to_string(&mandatory_table);

--- a/diesel-builders-derive/src/table_model.rs
+++ b/diesel-builders-derive/src/table_model.rs
@@ -271,6 +271,12 @@ pub fn derive_table_model_impl(input: &DeriveInput) -> syn::Result<TokenStream> 
     };
 
     if let Some(ancestors) = &attributes.ancestors {
+        if ancestors.is_empty() {
+            return Err(syn::Error::new_spanned(
+                input,
+                "`#[table_model(ancestors(...))]` must list at least one ancestor table",
+            ));
+        }
         let table_type_str = table_module.to_string();
 
         let mut seen = std::collections::HashSet::with_capacity(ancestors.len());

--- a/diesel-builders-derive/src/table_model/attribute_parsing.rs
+++ b/diesel-builders-derive/src/table_model/attribute_parsing.rs
@@ -152,7 +152,7 @@ pub fn extract_table_model_attributes(input: &DeriveInput) -> syn::Result<TableM
                 let _comma: syn::Token![,] = content.parse()?;
 
                 // Parse target
-                let referenced_columns = if content.peek(syn::token::Paren) {
+                let referenced_columns: Vec<syn::Path> = if content.peek(syn::token::Paren) {
                     let inner;
                     syn::parenthesized!(inner in content);
                     let punct: syn::punctuated::Punctuated<syn::Path, syn::Token![,]> =
@@ -161,6 +161,19 @@ pub fn extract_table_model_attributes(input: &DeriveInput) -> syn::Result<TableM
                 } else {
                     return Err(syn::Error::new(content.span(), "Expected list of columns"));
                 };
+
+                if host_columns.is_empty() {
+                    return Err(syn::Error::new(
+                        content.span(),
+                        "`foreign_key(...)` requires at least one host column",
+                    ));
+                }
+                if referenced_columns.is_empty() {
+                    return Err(syn::Error::new(
+                        content.span(),
+                        "`foreign_key(...)` requires at least one referenced column",
+                    ));
+                }
 
                 foreign_keys.push(ForeignKeyAttribute { host_columns, referenced_columns });
             }

--- a/diesel-builders-derive/src/table_model/foreign_keys.rs
+++ b/diesel-builders-derive/src/table_model/foreign_keys.rs
@@ -279,11 +279,8 @@ pub fn generate_fpk_impl(column: &syn::Path, referenced_table: &syn::Path) -> Op
 
     // Generate trait name
     // Extract table name from column path (second-to-last segment)
-    assert!(
-        column.segments.len() >= 2,
-        "Column path must have at least 2 segments (table::column)"
-    );
-    let table_name_segment = column.segments[column.segments.len() - 2].ident.to_string();
+    let table_index = column.segments.len().checked_sub(2)?;
+    let table_name_segment = column.segments[table_index].ident.to_string();
 
     // Convert table_name to CamelCase for trait name
     let trait_name = format!(

--- a/diesel-builders/src/builder_bundle.rs
+++ b/diesel-builders/src/builder_bundle.rs
@@ -368,7 +368,7 @@ where
 
 impl<Key> TrySetDiscretionaryBuilder<Key> for TableBuilderBundle<Key::Table>
 where
-    Key::Table: BundlableTable,
+    Key::Table: BundlableTableExt,
     Key: DiscretionarySameAsIndex,
     Key::ReferencedTable: BuildableTable,
     <Key::Table as BundlableTableExt>::OptionalDiscretionaryNestedBuilders: NestedTupleIndexMut<

--- a/diesel-builders/src/builder_bundle/completed_table_builder_bundle.rs
+++ b/diesel-builders/src/builder_bundle/completed_table_builder_bundle.rs
@@ -41,7 +41,7 @@ where
 impl<T, C> ValidateColumn<C> for CompletedTableBuilderBundle<T>
 where
     T: BundlableTableExt,
-    C: HorizontalSameAsGroupExt,
+    C: TypedColumn<Table = T>,
     T::NewValues: ValidateColumn<C>,
 {
     type Error = <T::NewValues as ValidateColumn<C>>::Error;
@@ -55,7 +55,7 @@ where
 impl<T, C> TrySetColumn<C> for CompletedTableBuilderBundle<T>
 where
     T: BundlableTableExt,
-    C: HorizontalSameAsGroupExt,
+    C: HorizontalSameAsGroupExt<Table = T>,
     Self: TrySetDiscretionarySameAsNestedColumns<
             C::ValueType,
             <T::NewValues as ValidateColumn<C>>::Error,

--- a/diesel-builders/src/get_foreign.rs
+++ b/diesel-builders/src/get_foreign.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// The `GetForeign` trait allows retrieving the foreign table
-/// model curresponding to specified foreign columns from a host table model.
+/// model corresponding to specified foreign columns from a host table model.
 pub trait GetForeign<
     Conn,
     HostColumns: NonEmptyProjection<Nested: NonEmptyNestedProjection>,

--- a/diesel-builders/src/load_nested_query_builder.rs
+++ b/diesel-builders/src/load_nested_query_builder.rs
@@ -120,7 +120,7 @@ pub trait LoadNestedMany<LeafTable, Conn>: LoadNestedQueryBuilder<LeafTable>
 where
     LeafTable: DescendantWithSelf + DescendantOfAll<Self::NestedTables>,
 {
-    /// Constructs a load query.
+    /// Returns all records matching the load query.
     ///
     /// # Arguments
     ///
@@ -162,7 +162,8 @@ pub trait LoadNestedSorted<LeafTable, Conn>: LoadNestedQueryBuilder<LeafTable>
 where
     LeafTable: DescendantWithSelf + DescendantOfAll<Self::NestedTables>,
 {
-    /// Constructs a load query.
+    /// Returns all records matching the load query, sorted by the leaf table's
+    /// primary key.
     ///
     /// # Arguments
     ///

--- a/diesel-builders/src/load_query_builder.rs
+++ b/diesel-builders/src/load_query_builder.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// The `LoadQueryBuilder` trait allows retrieving the foreign table
-/// model curresponding to specified foreign columns from a host table model.
+/// model corresponding to specified foreign columns from a host table model.
 pub trait LoadQueryBuilder: NonEmptyNestedProjection {
     /// The type of the constructed load query.
     type LoadQuery;
@@ -100,7 +100,7 @@ where
 
 /// The `LoadMany` trait allows retrieving several records from a load query.
 pub trait LoadMany<Conn>: LoadQueryBuilder<Table: TableExt> {
-    /// Constructs a load query.
+    /// Returns all records matching the load query.
     ///
     /// # Arguments
     ///
@@ -136,9 +136,9 @@ where
 }
 
 /// The `LoadSorted` trait allows retrieving several records from a load
-/// query, sorted by a given expression.
+/// query, sorted by the primary key.
 pub trait LoadSorted<Conn>: LoadQueryBuilder<Table: TableExt> {
-    /// Constructs a load query.
+    /// Returns all records matching the load query, sorted by the primary key.
     ///
     /// # Arguments
     ///
@@ -180,7 +180,7 @@ where
 }
 
 /// The `LoadPaginated` trait allows retrieving several records from a
-/// load query, sorted by a given expression with offset and limit for
+/// load query, sorted by the primary key with offset and limit for
 /// pagination.
 pub trait LoadPaginated<Conn>: LoadQueryBuilder<Table: TableExt> {
     /// Constructs a paginated load query.

--- a/diesel-builders/tests/ui_nightly/empty_ancestors_error.rs
+++ b/diesel-builders/tests/ui_nightly/empty_ancestors_error.rs
@@ -1,0 +1,11 @@
+use diesel_builders::prelude::*;
+
+#[derive(Debug, Clone, PartialEq, Queryable, Selectable, Identifiable, TableModel)]
+#[diesel(table_name = child_table)]
+#[table_model(ancestors())]
+pub struct Child {
+    id: i32,
+    name: String,
+}
+
+fn main() {}

--- a/diesel-builders/tests/ui_nightly/empty_ancestors_error.stderr
+++ b/diesel-builders/tests/ui_nightly/empty_ancestors_error.stderr
@@ -1,0 +1,10 @@
+error: `#[table_model(ancestors(...))]` must list at least one ancestor table
+ --> tests/ui_nightly/empty_ancestors_error.rs:4:1
+  |
+4 | / #[diesel(table_name = child_table)]
+5 | | #[table_model(ancestors())]
+6 | | pub struct Child {
+7 | |     id: i32,
+8 | |     name: String,
+9 | | }
+  | |_^

--- a/diesel-builders/tests/ui_nightly/empty_foreign_key_columns_error.rs
+++ b/diesel-builders/tests/ui_nightly/empty_foreign_key_columns_error.rs
@@ -1,0 +1,11 @@
+use diesel_builders::prelude::*;
+
+#[derive(Debug, Clone, PartialEq, Queryable, Selectable, Identifiable, TableModel)]
+#[diesel(table_name = child_table)]
+#[table_model(foreign_key(other_id, ()))]
+pub struct Child {
+    id: i32,
+    other_id: i32,
+}
+
+fn main() {}

--- a/diesel-builders/tests/ui_nightly/empty_foreign_key_columns_error.stderr
+++ b/diesel-builders/tests/ui_nightly/empty_foreign_key_columns_error.stderr
@@ -1,0 +1,5 @@
+error: `foreign_key(...)` requires at least one referenced column
+ --> tests/ui_nightly/empty_foreign_key_columns_error.rs:5:39
+  |
+5 | #[table_model(foreign_key(other_id, ()))]
+  |                                       ^

--- a/diesel-builders/tests/ui_nightly/same_as_under_segment_error.rs
+++ b/diesel-builders/tests/ui_nightly/same_as_under_segment_error.rs
@@ -1,0 +1,21 @@
+use diesel_builders::prelude::*;
+
+#[derive(Debug, Clone, PartialEq, Queryable, Selectable, Identifiable, TableModel)]
+#[diesel(table_name = mandatory_table)]
+pub struct Mandatory {
+    id: i32,
+    parent_id: i32,
+    mandatory_field: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Queryable, Selectable, Identifiable, TableModel)]
+#[diesel(table_name = child_table)]
+pub struct Child {
+    // The `#[same_as(...)]` path is a bare column with no `table::` prefix.
+    #[same_as(parent_id)]
+    id: i32,
+    #[mandatory(mandatory_table)]
+    mandatory_id: i32,
+}
+
+fn main() {}

--- a/diesel-builders/tests/ui_nightly/same_as_under_segment_error.stderr
+++ b/diesel-builders/tests/ui_nightly/same_as_under_segment_error.stderr
@@ -1,0 +1,5 @@
+error: Column path in `#[same_as(...)]` must be in the format `table::column`
+  --> tests/ui_nightly/same_as_under_segment_error.rs:15:15
+   |
+15 |     #[same_as(parent_id)]
+   |               ^^^^^^^^^


### PR DESCRIPTION
These are the latent nits the duplication re-survey turned up, none of them duplication.

The two completed-bundle impls had drifted bounds. CompletedTableBuilderBundle's ValidateColumn and TrySetColumn were missing the Table = T projection their TableBuilderBundle twins carry, and ValidateColumn used the heavier HorizontalSameAsGroupExt where the twin correctly uses TypedColumn, so both now match their twins. The discretionary builder impl also used BundlableTable where its mandatory twin uses BundlableTableExt, now aligned.

The flat load-query trait docs claimed results are sorted by a given expression when the impls sort by the primary key, and several method docs said Constructs a load query on methods that actually execute and return records, so those are corrected on both the flat and nested traits, along with a curresponding typo copied into get_foreign.

Two proc-macro panics on malformed input are gone. A same_as path with fewer than two segments now yields a spanned compile error instead of an assert panic, and generate_fpk_impl skips a malformed column through its existing Option return rather than asserting. The remaining segments.last().unwrap() calls sit on freshly parsed, non-empty paths and cannot panic, so they are left as is. Valid inputs are unaffected and the full suite plus clippy, docs, and the coverage build pass.

## Summary by Sourcery

Harden table-model macro validation and align builder constraints and API documentation with actual behavior.

Bug Fixes:
- Prevent malformed table-model, foreign-key, and same-as inputs from causing proc-macro panics by returning compile-time errors instead.
- Align completed and discretionary builder trait constraints with their corresponding builder implementations.

Enhancements:
- Correct load-query API documentation to describe returned records and primary-key ordering.

Documentation:
- Fix inaccurate load-query behavior descriptions and a typo in foreign-table documentation.

Tests:
- Add UI coverage for empty ancestor and foreign-key declarations and malformed same-as paths.