### PR TITLE
Fold three low-risk foreign-key duplications into shared code

### DIFF
--- a/diesel-builders-derive/src/table_model/foreign_keys.rs
+++ b/diesel-builders-derive/src/table_model/foreign_keys.rs
@@ -611,7 +611,7 @@ fn generate_impls_for_groups<'b>(
     let mut dyn_impl_branches = Vec::new();
 
     for (_, (ref_cols, keys)) in groups {
-        let idx_type = recursive_tuple_type(ref_cols);
+        let idx_type = crate::utils::format_as_nested_tuple(ref_cols);
 
         assert!(!keys.is_empty(), "Cannot generate iterator for empty key group");
         let first_key = keys[0];
@@ -643,7 +643,7 @@ fn generate_impls_for_groups<'b>(
         // MatchSimpleIter: Nested tuple of Option<&T>
         let simple_item_types: Vec<_> =
             base_types.iter().map(|ty| quote!(::std::option::Option<&'a #ty>)).collect();
-        let simple_elem_ty = recursive_tuple_type(&simple_item_types);
+        let simple_elem_ty = crate::utils::format_as_nested_tuple(&simple_item_types);
         // Nested Dyn Index
         let dyn_elem_ty = recursive_dyn_tuple_type(&base_types);
 
@@ -785,7 +785,7 @@ fn build_single_key_iterators(
     }
 
     // Simple Iter
-    let simple_tuple_expr = recursive_tuple_expr(&simple_val_tokens);
+    let simple_tuple_expr = crate::utils::format_as_nested_tuple(&simple_val_tokens);
     let simple_iter_expr = quote!(::std::iter::once(#simple_tuple_expr));
     let simple_iter_type = quote!(::std::iter::Once<#simple_elem_ty>);
 
@@ -799,7 +799,7 @@ fn build_single_key_iterators(
     // Tuple pattern: (Some(v0), v1, ...)
     let match_pattern = quote!((#(#match_pats,)*));
 
-    let full_tuple_val = recursive_tuple_expr(&full_construction_vars);
+    let full_tuple_val = crate::utils::format_as_nested_tuple(&full_construction_vars);
 
     let full_opt_expr = quote! {
         match #match_target {
@@ -843,35 +843,6 @@ fn build_foreign_keys_iterator(
 }
 
 // Helpers for nested tuples
-/// Recursively builds a nested tuple type from a slice of types.
-/// `[A, B, C]` -> `(A, (B, (C,)))` (with unit termination if needed, or
-/// specific structure) Actually implementation logic:
-/// `[]` -> `()`
-/// `[single]` -> `(single,)`
-/// `[head, tail...]` -> `(head, tail_recursion)`
-/// e.g. `[A, B, C]` -> `(A, (B, (C,)))`
-fn recursive_tuple_type(types: &[TokenStream]) -> TokenStream {
-    match types {
-        [] => quote!(()),
-        [single] => quote!((#single,)),
-        [head, tail @ ..] => {
-            let tail_tokens = recursive_tuple_type(tail);
-            quote!((#head, #tail_tokens))
-        }
-    }
-}
-
-/// Recursively builds a nested tuple expression from a slice of expressions.
-fn recursive_tuple_expr(exprs: &[TokenStream]) -> TokenStream {
-    match exprs {
-        [] => quote!(()),
-        [single] => quote!((#single,)),
-        [head, tail @ ..] => {
-            let tail_tokens = recursive_tuple_expr(tail);
-            quote!((#head, #tail_tokens))
-        }
-    }
-}
 
 /// Recursively builds a nested tuple expression from a slice of expressions
 /// used to build a Dynamic Column Index

--- a/diesel-builders/src/foreign_key.rs
+++ b/diesel-builders/src/foreign_key.rs
@@ -9,87 +9,77 @@ use crate::{
     columns::{NonEmptyNestedProjection, NonEmptyProjection},
 };
 
-/// A trait defining a table index for Diesel tables.
-pub trait TableIndex: NonEmptyProjection {}
-impl<I> TableIndex for I where
-    I: NonEmptyProjection + NestTuple<Nested: NestedTableIndexTail<typenum::U0, I>>
-{
+/// Emits the index-trait family (`…TableIndex`, `Nested…TableIndexTail`, and
+/// the per-column `…IndexedColumn`) for one flavour, plain or unique. The two
+/// flavours are identical apart from their trait names, so both are generated
+/// from this template.
+macro_rules! index_traits {
+    (
+        kind = $kind:literal,
+        table_index = $table_index:ident,
+        nested_tail = $nested_tail:ident,
+        column = $column:ident $(,)?
+    ) => {
+        #[doc = concat!("A trait defining a ", $kind, "table index for Diesel tables.")]
+        pub trait $table_index: NonEmptyProjection {}
+        impl<I> $table_index for I where
+            I: NonEmptyProjection + NestTuple<Nested: $nested_tail<typenum::U0, I>>
+        {
+        }
+
+        #[doc = concat!(
+            "A trait defining a tail of a ", $kind,
+            "table index starting from a given index.\n\nThis trait may not \
+             define a full index, but only the tail part starting from a given \
+             index."
+        )]
+        pub trait $nested_tail<Idx, FullIndex>: NonEmptyNestedProjection {}
+
+        impl<Idx, C1, FullIndex> $nested_tail<Idx, FullIndex> for (C1,)
+        where
+            C1: $column<Idx, FullIndex, Table: TableExt>,
+            FullIndex: NonEmptyProjection<Table = C1::Table>,
+            <FullIndex as NestTuple>::Nested: NestedTupleIndex<Idx, Element = C1>,
+        {
+        }
+
+        impl<Idx, CHead, Ctail, FullIndex> $nested_tail<Idx, FullIndex> for (CHead, Ctail)
+        where
+            (CHead, Ctail): NonEmptyNestedProjection<Table = CHead::Table>
+                + FlattenNestedTuple<Flattened: NonEmptyProjection<Table = CHead::Table>>,
+            CHead: $column<Idx, FullIndex>,
+            Ctail: $nested_tail<typenum::Add1<Idx>, FullIndex>,
+            Idx: core::ops::Add<typenum::B1>,
+            FullIndex: NonEmptyProjection<Table = CHead::Table>,
+            <FullIndex as NestTuple>::Nested: NestedTupleIndex<Idx, Element = CHead>,
+        {
+        }
+
+        #[doc = concat!("A trait for Diesel columns which are part of a ", $kind, "table index.")]
+        pub trait $column<
+            Idx,
+            IndexedColumns: NonEmptyProjection<Table = Self::Table, Nested: NestedTupleIndex<Idx, Element = Self>>,
+        >: TypedColumn
+        {
+        }
+    };
 }
 
-/// A trait defining a UNIQUE table index for Diesel tables.
-pub trait UniqueTableIndex: NonEmptyProjection {}
-impl<I> UniqueTableIndex for I where
-    I: NonEmptyProjection + NestTuple<Nested: NestedUniqueTableIndexTail<typenum::U0, I>>
-{
+index_traits! {
+    kind = "",
+    table_index = TableIndex,
+    nested_tail = NestedTableIndexTail,
+    column = IndexedColumn,
 }
 
-/// A trait defining a tail of a table index starting from a given index.
-///
-/// This trait may not define a full index, but only the tail part starting
-/// from a given index.
-pub trait NestedTableIndexTail<Idx, FullIndex>: NonEmptyNestedProjection {}
-
-impl<Idx, C1, FullIndex> NestedTableIndexTail<Idx, FullIndex> for (C1,)
-where
-    C1: IndexedColumn<Idx, FullIndex, Table: TableExt>,
-    FullIndex: NonEmptyProjection<Table = C1::Table>,
-    <FullIndex as NestTuple>::Nested: NestedTupleIndex<Idx, Element = C1>,
-{
+index_traits! {
+    kind = "UNIQUE ",
+    table_index = UniqueTableIndex,
+    nested_tail = NestedUniqueTableIndexTail,
+    column = UniquelyIndexedColumn,
 }
 
-impl<Idx, CHead, Ctail, FullIndex> NestedTableIndexTail<Idx, FullIndex> for (CHead, Ctail)
-where
-    (CHead, Ctail): NonEmptyNestedProjection<Table = CHead::Table>
-        + FlattenNestedTuple<Flattened: NonEmptyProjection<Table = CHead::Table>>,
-    CHead: IndexedColumn<Idx, FullIndex>,
-    Ctail: NestedTableIndexTail<typenum::Add1<Idx>, FullIndex>,
-    Idx: core::ops::Add<typenum::B1>,
-    FullIndex: NonEmptyProjection<Table = CHead::Table>,
-    <FullIndex as NestTuple>::Nested: NestedTupleIndex<Idx, Element = CHead>,
-{
-}
-
-/// A trait defining a tail of a UNIQUE table index starting from a given index.
-///
-/// This trait may not define a full index, but only the tail part starting
-/// from a given index.
-pub trait NestedUniqueTableIndexTail<Idx, FullIndex>: NonEmptyNestedProjection {}
-
-impl<Idx, C1, FullIndex> NestedUniqueTableIndexTail<Idx, FullIndex> for (C1,)
-where
-    C1: UniquelyIndexedColumn<Idx, FullIndex, Table: TableExt>,
-    FullIndex: NonEmptyProjection<Table = C1::Table>,
-    <FullIndex as NestTuple>::Nested: NestedTupleIndex<Idx, Element = C1>,
-{
-}
-
-impl<Idx, CHead, Ctail, FullIndex> NestedUniqueTableIndexTail<Idx, FullIndex> for (CHead, Ctail)
-where
-    (CHead, Ctail): NonEmptyNestedProjection<Table = CHead::Table>
-        + FlattenNestedTuple<Flattened: NonEmptyProjection<Table = CHead::Table>>,
-    CHead: UniquelyIndexedColumn<Idx, FullIndex>,
-    Ctail: NestedUniqueTableIndexTail<typenum::Add1<Idx>, FullIndex>,
-    Idx: core::ops::Add<typenum::B1>,
-    FullIndex: NonEmptyProjection<Table = CHead::Table>,
-    <FullIndex as NestTuple>::Nested: NestedTupleIndex<Idx, Element = CHead>,
-{
-}
-
-/// A trait for Diesel columns which are part of a `NestedTableIndex`.
-pub trait IndexedColumn<
-    Idx,
-    IndexedColumns: NonEmptyProjection<Table = Self::Table, Nested: NestedTupleIndex<Idx, Element = Self>>,
->: TypedColumn
-{
-}
-
-/// A trait for Diesel columns which are part of a `NestedUniqueTableIndex`.
-pub trait UniquelyIndexedColumn<
-    Idx,
-    UniquelyIndexedColumns: NonEmptyProjection<Table = Self::Table, Nested: NestedTupleIndex<Idx, Element = Self>>,
->: TypedColumn
-{
-}
+// Every uniquely-indexed column is also an ordinarily indexed column.
 impl<Idx, C, IndexedColumns> IndexedColumn<Idx, IndexedColumns> for C
 where
     C: UniquelyIndexedColumn<Idx, IndexedColumns>,

--- a/diesel-builders/src/get_column/dynamic.rs
+++ b/diesel-builders/src/get_column/dynamic.rs
@@ -62,23 +62,7 @@ macro_rules! impl_try_get_dynamic_column {
     };
 }
 
-impl_try_get_dynamic_column!(&Head, Box<Head>, std::rc::Rc<Head>, std::sync::Arc<Head>);
-
-impl<Head> TryGetDynamicColumn for (Head,)
-where
-    Head: HasTableExt,
-    Self: sealed::VariadicTryGetDynamicColumn<
-            <<Head::Table as Table>::AllColumns as NestTuple>::Nested,
-        >,
-{
-    #[inline]
-    fn try_get_dynamic_column_ref<VT: 'static>(
-        &self,
-        column: DynColumn<VT>,
-    ) -> Result<Option<&VT>, DynamicColumnError> {
-        self.variadic_try_get_dynamic_column(column)
-    }
-}
+impl_try_get_dynamic_column!(&Head, Box<Head>, std::rc::Rc<Head>, std::sync::Arc<Head>, (Head,));
 
 impl<Head, Tail> TryGetDynamicColumn for (Head, Tail)
 where


### PR DESCRIPTION
Three small, behavior-preserving deduplications the re-survey flagged as low risk.

In the core foreign_key module the plain and unique index trait families, TableIndex with NestedTableIndexTail and IndexedColumn plus their Unique twins, were identical apart from their names, so both are now produced by one index_traits macro invoked twice, keeping the uniquely-indexed to indexed bridging blanket hand-written since it is the only piece that genuinely differs.

In the derive crate recursive_tuple_type and recursive_tuple_expr built the same nested tuple that utils format_as_nested_tuple already builds, so both are removed and their four call sites go through the shared helper, while the DynColumn-wrapping variants stay because they wrap each element.

In the dynamic column module the standalone TryGetDynamicColumn impl for a one-element tuple was a verbatim copy of the impl_try_get_dynamic_column macro output, so the tuple is folded into the macro invocation and the duplicate impl deleted.

The generated code and public trait names are unchanged, and the full test suite plus clippy, docs, and the coverage build pass.

## Summary by Sourcery

Consolidate duplicated foreign-key, tuple-generation, and dynamic-column implementations without changing generated code or public behavior.

Enhancements:
- Consolidate the plain and unique foreign-key index trait families behind a shared macro while preserving their public APIs and distinct bridging behavior.
- Reuse the shared nested-tuple formatter throughout foreign-key code generation instead of maintaining duplicate tuple-building helpers.
- Fold one-element dynamic-column tuple support into the existing implementation macro.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The code contained duplicate implementations for index traits, tuple formatting, and single element dynamic columns. This increased maintenance cost without changing behavior.

The refactoring centralizes repeated generation while preserving public trait names and generated code. Existing validation confirms that the test suite, clippy, documentation, and coverage build pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->