### PR TITLE
Collapse duplicated core trait impls behind macros

### DIFF
--- a/diesel-builders/src/builder_bundle.rs
+++ b/diesel-builders/src/builder_bundle.rs
@@ -167,17 +167,104 @@ where
     }
 }
 
-impl<T> HasTable for TableBuilderBundle<T>
-where
-    T: BundlableTableExt,
-{
-    type Table = T;
+/// Emits the trait impls shared verbatim by [`TableBuilderBundle`] and
+/// [`CompletedTableBuilderBundle`].
+///
+/// Both structs carry the same `insertable_model` plus discretionary builder
+/// fields, so `HasTable`, `ValidateColumn`, `TrySetColumn`, and the
+/// discretionary same-as setter delegate identically. The mandatory same-as
+/// setter differs (optional versus de-optioned builders) and stays per-struct.
+macro_rules! impl_bundle_shared {
+    ($bundle:ident) => {
+        impl<T> HasTable for $bundle<T>
+        where
+            T: BundlableTableExt,
+        {
+            type Table = T;
 
-    #[inline]
-    fn table() -> Self::Table {
-        T::default()
-    }
+            #[inline]
+            fn table() -> Self::Table {
+                T::default()
+            }
+        }
+
+        impl<T, C> ValidateColumn<C> for $bundle<T>
+        where
+            T: BundlableTableExt,
+            C: TypedColumn<Table = T>,
+            T::NewValues: ValidateColumn<C>,
+        {
+            type Error = <T::NewValues as ValidateColumn<C>>::Error;
+
+            #[inline]
+            fn validate_column_in_context(&self, value: &C::ValueType) -> Result<(), Self::Error> {
+                self.insertable_model.validate_column_in_context(value)
+            }
+        }
+
+        impl<T, C> TrySetColumn<C> for $bundle<T>
+        where
+            T: BundlableTableExt,
+            C: HorizontalSameAsGroupExt<Table = T>,
+            Self: TrySetDiscretionarySameAsNestedColumns<
+                    C::ValueType,
+                    <T::NewValues as ValidateColumn<C>>::Error,
+                    C::NestedDiscretionaryHorizontalKeys,
+                    C::NestedDiscretionaryForeignColumns,
+                > + TrySetMandatorySameAsNestedColumns<
+                    C::ValueType,
+                    <T::NewValues as ValidateColumn<C>>::Error,
+                    C::NestedMandatoryHorizontalKeys,
+                    C::NestedMandatoryForeignColumns,
+                >,
+            T::NewValues: TrySetColumn<C>,
+        {
+            #[inline]
+            fn try_set_column(
+                &mut self,
+                value: impl Into<C::ColumnType>,
+            ) -> Result<&mut Self, Self::Error> {
+                let value = value.into();
+                if let Some(value_ref) = value.as_optional_ref() {
+                    self.validate_column_in_context(value_ref)?;
+                }
+                self.try_set_discretionary_same_as_nested_columns(&value)?;
+                self.try_set_mandatory_same_as_nested_columns(&value)?;
+                self.insertable_model.try_set_column(value)?;
+                Ok(self)
+            }
+        }
+
+        impl<
+            Key: DiscretionarySameAsIndex<Table: BundlableTableExt, ReferencedTable: BuildableTable>,
+            C,
+        > TrySetDiscretionarySameAsColumn<Key, C> for $bundle<<Key as Column>::Table>
+        where
+            C: TypedColumn<Table = Key::ReferencedTable>,
+            <Key::Table as BundlableTableExt>::OptionalDiscretionaryNestedBuilders:
+                NestedTupleIndexMut<Key::Idx, Element = Option<TableBuilder<C::Table>>>,
+            TableBuilder<C::Table>: TrySetColumn<C>,
+        {
+            type Error = <TableBuilder<C::Table> as ValidateColumn<C>>::Error;
+
+            #[inline]
+            fn try_set_discretionary_same_as_column(
+                &mut self,
+                value: impl Into<C::ColumnType>,
+            ) -> Result<&mut Self, Self::Error> {
+                if let Some(builder) =
+                    self.nested_discretionary_associated_builders.nested_index_mut().as_mut()
+                {
+                    builder.try_set_column(value)?;
+                }
+                Ok(self)
+            }
+        }
+    };
 }
+pub(crate) use impl_bundle_shared;
+
+impl_bundle_shared!(TableBuilderBundle);
 
 impl<T, C> MayGetColumn<C> for TableBuilderBundle<T>
 where
@@ -188,20 +275,6 @@ where
     #[inline]
     fn may_get_column_ref(&self) -> Option<&C::ColumnType> {
         self.insertable_model.may_get_column_ref()
-    }
-}
-
-impl<T, C> ValidateColumn<C> for TableBuilderBundle<T>
-where
-    T: BundlableTableExt,
-    C: TypedColumn<Table = T>,
-    T::NewValues: ValidateColumn<C>,
-{
-    type Error = <T::NewValues as ValidateColumn<C>>::Error;
-
-    #[inline]
-    fn validate_column_in_context(&self, value: &C::ValueType) -> Result<(), Self::Error> {
-        self.insertable_model.validate_column_in_context(value)
     }
 }
 
@@ -230,39 +303,6 @@ where
     }
 }
 
-impl<T, C> TrySetColumn<C> for TableBuilderBundle<T>
-where
-    T: BundlableTableExt,
-    C: HorizontalSameAsGroupExt<Table = T>,
-    Self: TrySetDiscretionarySameAsNestedColumns<
-            C::ValueType,
-            <T::NewValues as ValidateColumn<C>>::Error,
-            C::NestedDiscretionaryHorizontalKeys,
-            C::NestedDiscretionaryForeignColumns,
-        > + TrySetMandatorySameAsNestedColumns<
-            C::ValueType,
-            <T::NewValues as ValidateColumn<C>>::Error,
-            C::NestedMandatoryHorizontalKeys,
-            C::NestedMandatoryForeignColumns,
-        >,
-    T::NewValues: TrySetColumn<C>,
-{
-    #[inline]
-    fn try_set_column(
-        &mut self,
-        value: impl Into<C::ColumnType>,
-    ) -> Result<&mut Self, Self::Error> {
-        let value = value.into();
-        if let Some(value_ref) = value.as_optional_ref() {
-            self.validate_column_in_context(value_ref)?;
-        }
-        self.try_set_discretionary_same_as_nested_columns(&value)?;
-        self.try_set_mandatory_same_as_nested_columns(&value)?;
-        self.insertable_model.try_set_column(value)?;
-        Ok(self)
-    }
-}
-
 impl<Key: MandatorySameAsIndex<Table: BundlableTableExt, ReferencedTable: BuildableTable>, C>
     TrySetMandatorySameAsColumn<Key, C> for TableBuilderBundle<<Key as Column>::Table>
 where
@@ -279,30 +319,6 @@ where
         value: impl Into<C::ColumnType>,
     ) -> Result<&mut Self, Self::Error> {
         if let Some(builder) = self.nested_mandatory_associated_builders.nested_index_mut() {
-            builder.try_set_column(value)?;
-        }
-        Ok(self)
-    }
-}
-
-impl<Key: DiscretionarySameAsIndex<Table: BundlableTableExt, ReferencedTable: BuildableTable>, C>
-    TrySetDiscretionarySameAsColumn<Key, C> for TableBuilderBundle<<Key as Column>::Table>
-where
-    C: TypedColumn<Table = Key::ReferencedTable>,
-    <Key::Table as BundlableTableExt>::OptionalDiscretionaryNestedBuilders:
-        NestedTupleIndexMut<Key::Idx, Element = Option<TableBuilder<C::Table>>>,
-    TableBuilder<Key::ReferencedTable>: TrySetColumn<C>,
-{
-    type Error = <TableBuilder<C::Table> as ValidateColumn<C>>::Error;
-
-    #[inline]
-    fn try_set_discretionary_same_as_column(
-        &mut self,
-        value: impl Into<C::ColumnType>,
-    ) -> Result<&mut Self, Self::Error> {
-        if let Some(builder) =
-            self.nested_discretionary_associated_builders.nested_index_mut().as_mut()
-        {
             builder.try_set_column(value)?;
         }
         Ok(self)

--- a/diesel-builders/src/builder_bundle/completed_table_builder_bundle.rs
+++ b/diesel-builders/src/builder_bundle/completed_table_builder_bundle.rs
@@ -11,7 +11,8 @@ use crate::{
     TrySetDiscretionarySameAsNestedColumns, TrySetMandatorySameAsColumn,
     TrySetMandatorySameAsNestedColumns, TrySetNestedColumns, TupleGetNestedColumns,
     TupleMayGetNestedColumns, TypedColumn, TypedNestedTuple, ValidateColumn,
-    builder_bundle::BundlableTableExt, columns::TupleEqAll,
+    builder_bundle::{BundlableTableExt, impl_bundle_shared},
+    columns::TupleEqAll,
     horizontal_same_as_group::HorizontalSameAsGroupExt,
 };
 
@@ -26,64 +27,7 @@ pub struct CompletedTableBuilderBundle<T: BundlableTableExt> {
     nested_discretionary_associated_builders: T::OptionalDiscretionaryNestedBuilders,
 }
 
-impl<T> HasTable for CompletedTableBuilderBundle<T>
-where
-    T: BundlableTableExt,
-{
-    type Table = T;
-
-    #[inline]
-    fn table() -> Self::Table {
-        T::default()
-    }
-}
-
-impl<T, C> ValidateColumn<C> for CompletedTableBuilderBundle<T>
-where
-    T: BundlableTableExt,
-    C: TypedColumn<Table = T>,
-    T::NewValues: ValidateColumn<C>,
-{
-    type Error = <T::NewValues as ValidateColumn<C>>::Error;
-
-    #[inline]
-    fn validate_column_in_context(&self, value: &C::ValueType) -> Result<(), Self::Error> {
-        self.insertable_model.validate_column_in_context(value)
-    }
-}
-
-impl<T, C> TrySetColumn<C> for CompletedTableBuilderBundle<T>
-where
-    T: BundlableTableExt,
-    C: HorizontalSameAsGroupExt<Table = T>,
-    Self: TrySetDiscretionarySameAsNestedColumns<
-            C::ValueType,
-            <T::NewValues as ValidateColumn<C>>::Error,
-            C::NestedDiscretionaryHorizontalKeys,
-            C::NestedDiscretionaryForeignColumns,
-        > + TrySetMandatorySameAsNestedColumns<
-            C::ValueType,
-            <T::NewValues as ValidateColumn<C>>::Error,
-            C::NestedMandatoryHorizontalKeys,
-            C::NestedMandatoryForeignColumns,
-        >,
-    T::NewValues: TrySetColumn<C>,
-{
-    #[inline]
-    fn try_set_column(
-        &mut self,
-        value: impl Into<C::ColumnType>,
-    ) -> Result<&mut Self, Self::Error> {
-        let value = value.into();
-        if let Some(value_ref) = value.as_optional_ref() {
-            self.validate_column_in_context(value_ref)?;
-        }
-        self.try_set_discretionary_same_as_nested_columns(&value)?;
-        self.try_set_mandatory_same_as_nested_columns(&value)?;
-        self.insertable_model.try_set_column(value)?;
-        Ok(self)
-    }
-}
+impl_bundle_shared!(CompletedTableBuilderBundle);
 
 impl<Key: MandatorySameAsIndex<Table: BundlableTableExt, ReferencedTable: BuildableTable>, C>
     TrySetMandatorySameAsColumn<Key, C> for CompletedTableBuilderBundle<<Key as Column>::Table>
@@ -101,30 +45,6 @@ where
         value: impl Into<C::ColumnType>,
     ) -> Result<&mut Self, Self::Error> {
         self.nested_mandatory_associated_builders.nested_index_mut().try_set_column(value)?;
-        Ok(self)
-    }
-}
-
-impl<Key: DiscretionarySameAsIndex<Table: BundlableTableExt, ReferencedTable: BuildableTable>, C>
-    TrySetDiscretionarySameAsColumn<Key, C> for CompletedTableBuilderBundle<<Key as Column>::Table>
-where
-    C: TypedColumn<Table = Key::ReferencedTable>,
-    <Key::Table as BundlableTableExt>::OptionalDiscretionaryNestedBuilders:
-        NestedTupleIndexMut<Key::Idx, Element = Option<TableBuilder<C::Table>>>,
-    TableBuilder<C::Table>: TrySetColumn<C>,
-{
-    type Error = <TableBuilder<C::Table> as ValidateColumn<C>>::Error;
-
-    #[inline]
-    fn try_set_discretionary_same_as_column(
-        &mut self,
-        value: impl Into<C::ColumnType>,
-    ) -> Result<&mut Self, Self::Error> {
-        if let Some(builder) =
-            self.nested_discretionary_associated_builders.nested_index_mut().as_mut()
-        {
-            builder.try_set_column(value)?;
-        }
         Ok(self)
     }
 }

--- a/diesel-builders/src/get_column/blanket_impls.rs
+++ b/diesel-builders/src/get_column/blanket_impls.rs
@@ -2,66 +2,30 @@
 
 use crate::{TypedColumn, get_column::GetColumn};
 
-impl<C, T> GetColumn<C> for &T
-where
-    C: TypedColumn,
-    T: GetColumn<C>,
-{
-    #[inline]
-    fn get_column_ref(&self) -> &C::ColumnType {
-        (*self).get_column_ref()
-    }
+/// Forwards `GetColumn` through each transparent smart-pointer wrapper.
+///
+/// Every wrapper delegates identically via `(**self)`, which reaches the inner
+/// `T` for `&T`, `Box<T>`, `Rc<T>`, and `Arc<T>` alike.
+macro_rules! impl_get_column_for_wrapper {
+    ($($wrapper:ty),+ $(,)?) => {
+        $(
+            impl<C, T> GetColumn<C> for $wrapper
+            where
+                C: TypedColumn,
+                T: GetColumn<C>,
+            {
+                #[inline]
+                fn get_column_ref(&self) -> &C::ColumnType {
+                    (**self).get_column_ref()
+                }
 
-    #[inline]
-    fn get_column(&self) -> C::ColumnType {
-        (*self).get_column()
-    }
+                #[inline]
+                fn get_column(&self) -> C::ColumnType {
+                    (**self).get_column()
+                }
+            }
+        )+
+    };
 }
 
-impl<C, T> GetColumn<C> for Box<T>
-where
-    C: TypedColumn,
-    T: GetColumn<C>,
-{
-    #[inline]
-    fn get_column_ref(&self) -> &C::ColumnType {
-        (**self).get_column_ref()
-    }
-
-    #[inline]
-    fn get_column(&self) -> C::ColumnType {
-        (**self).get_column()
-    }
-}
-
-impl<C, T> GetColumn<C> for std::rc::Rc<T>
-where
-    C: TypedColumn,
-    T: GetColumn<C>,
-{
-    #[inline]
-    fn get_column_ref(&self) -> &C::ColumnType {
-        (**self).get_column_ref()
-    }
-
-    #[inline]
-    fn get_column(&self) -> C::ColumnType {
-        (**self).get_column()
-    }
-}
-
-impl<C, T> GetColumn<C> for std::sync::Arc<T>
-where
-    C: TypedColumn,
-    T: GetColumn<C>,
-{
-    #[inline]
-    fn get_column_ref(&self) -> &C::ColumnType {
-        (**self).get_column_ref()
-    }
-
-    #[inline]
-    fn get_column(&self) -> C::ColumnType {
-        (**self).get_column()
-    }
-}
+impl_get_column_for_wrapper!(&T, Box<T>, std::rc::Rc<T>, std::sync::Arc<T>);

--- a/diesel-builders/src/set_column.rs
+++ b/diesel-builders/src/set_column.rs
@@ -73,42 +73,38 @@ pub trait TrySetColumn<C: ColumnTyped>: ValidateColumn<C> {
     -> Result<&mut Self, Self::Error>;
 }
 
-impl<T, C> TrySetColumn<C> for (T,)
-where
-    Self: SetColumn<C> + ValidateColumn<C>,
-    C: TypedColumn,
-{
-    #[inline]
-    fn try_set_column(
-        &mut self,
-        value: impl Into<C::ColumnType>,
-    ) -> Result<&mut Self, Self::Error> {
-        let value = value.into();
-        if let Some(value_ref) = value.as_optional_ref() {
-            <Self as ValidateColumn<C>>::validate_column_in_context(self, value_ref)?;
-        }
-        <Self as SetColumn<C>>::set_column(self, value);
-        Ok(self)
-    }
+/// Emits the identical leaf `TrySetColumn` body for each `NewValues` tuple
+/// arity. These are non-recursive leaf impls (the derive emits per-column
+/// `SetColumn`/`ValidateColumn` on `NewValues`), so both arities share one
+/// body that validates an optional value then sets it.
+macro_rules! impl_try_set_column_for_tuple {
+    ($( impl[$($generics:ident),+] for $tuple:ty ),+ $(,)?) => {
+        $(
+            impl<$($generics),+, C> TrySetColumn<C> for $tuple
+            where
+                Self: SetColumn<C> + ValidateColumn<C>,
+                C: TypedColumn,
+            {
+                #[inline]
+                fn try_set_column(
+                    &mut self,
+                    value: impl Into<C::ColumnType>,
+                ) -> Result<&mut Self, Self::Error> {
+                    let value = value.into();
+                    if let Some(value_ref) = value.as_optional_ref() {
+                        <Self as ValidateColumn<C>>::validate_column_in_context(self, value_ref)?;
+                    }
+                    <Self as SetColumn<C>>::set_column(self, value);
+                    Ok(self)
+                }
+            }
+        )+
+    };
 }
 
-impl<Head, Tail, C> TrySetColumn<C> for (Head, Tail)
-where
-    Self: SetColumn<C> + ValidateColumn<C>,
-    C: TypedColumn,
-{
-    #[inline]
-    fn try_set_column(
-        &mut self,
-        value: impl Into<C::ColumnType>,
-    ) -> Result<&mut Self, Self::Error> {
-        let value = value.into();
-        if let Some(value_ref) = value.as_optional_ref() {
-            <Self as ValidateColumn<C>>::validate_column_in_context(self, value_ref)?;
-        }
-        <Self as SetColumn<C>>::set_column(self, value);
-        Ok(self)
-    }
+impl_try_set_column_for_tuple! {
+    impl[T] for (T,),
+    impl[Head, Tail] for (Head, Tail),
 }
 
 /// Extension trait for [`SetColumn`] that allows specifying the column at the

--- a/diesel-builders/src/table_builder.rs
+++ b/diesel-builders/src/table_builder.rs
@@ -180,111 +180,118 @@ where
     }
 }
 
-impl<Key, T> TrySetMandatoryBuilder<Key> for TableBuilder<T>
-where
-    T: BuildableTable
-        + DescendantOf<
-            Key::Table,
-            NestedPrimaryKeyColumns: NestedColumns<
-                NestedTupleColumnType = (
-                    <<Key::Table as Table>::PrimaryKey as ColumnTyped>::ColumnType,
-                ),
-            >,
+/// Emits the `TableBuilder<T>` triangular builder-setter impls.
+///
+/// The mandatory and discretionary variants share one body per fallibility:
+/// read the referenced builder's nested foreign columns, propagate them into
+/// this builder, and delegate the builder itself to the ancestor bundle. They
+/// differ only in the key marker, the bundle trait delegated to, the method
+/// name, and (for the fallible mandatory case) an extra single-column primary
+/// key bound.
+macro_rules! impl_builder_setters {
+    (
+        @fallible
+        trait = $trait:ident,
+        method = $method:ident,
+        index = $index:ident,
+        bundle_trait = $bundle_trait:ident,
+        descendant = [$($descendant:tt)+] $(,)?
+    ) => {
+        impl<Key, T> $trait<Key> for TableBuilder<T>
+        where
+            T: BuildableTable + $($descendant)+,
+            Key: $index,
+            Key::Table: AncestorOfIndex<T> + BuildableTable,
+            Key::ReferencedTable: BuildableTable,
+            Self: TryMaySetNestedColumns<T::Error, Key::NestedHostColumns>
+                + MayValidateNestedColumns<T::Error, Key::NestedHostColumns>
+                + AncestorBundleMut<Key::Table>,
+            TableBuilder<Key::ReferencedTable>: MayGetNestedColumns<Key::NestedForeignColumns>,
+            TableBuilderBundle<Key::Table>: $bundle_trait<Key, Table = Key::Table>,
+            T::Error: From<<Key::Table as TableExt>::Error>,
+        {
+            #[inline]
+            fn $method(
+                &mut self,
+                builder: TableBuilder<<Key as ForeignPrimaryKey>::ReferencedTable>,
+            ) -> Result<&mut Self, T::Error> {
+                let columns = builder.may_get_nested_columns();
+                let converted_columns = columns.nested_tuple_option_into();
+                self.may_validate_nested_columns(&converted_columns)?;
+                self.ancestor_bundle_mut().$method(builder)?;
+                self.try_may_set_nested_columns(converted_columns)?;
+                Ok(self)
+            }
+        }
+    };
+    (
+        @infallible
+        trait = $trait:ident,
+        method = $method:ident,
+        index = $index:ident,
+        bundle_trait = $bundle_trait:ident $(,)?
+    ) => {
+        impl<Key, T> $trait<Key> for TableBuilder<T>
+        where
+            T: BuildableTable + DescendantOf<Key::Table>,
+            Key: $index,
+            Key::Table: AncestorOfIndex<T> + BuildableTable,
+            Key::ReferencedTable: BuildableTable,
+            Self: MaySetColumns<Key::NestedHostColumns> + AncestorBundleMut<Key::Table>,
+            TableBuilderBundle<Key::Table>: $bundle_trait<Key>,
+            TableBuilder<<Key as ForeignPrimaryKey>::ReferencedTable>:
+                MayGetNestedColumns<Key::NestedForeignColumns>,
+        {
+            #[inline]
+            fn $method(
+                &mut self,
+                builder: TableBuilder<<Key as ForeignPrimaryKey>::ReferencedTable>,
+            ) -> &mut Self {
+                let columns = builder.may_get_nested_columns();
+                let converted_columns = columns.nested_tuple_option_into();
+                self.may_set_nested_columns(converted_columns);
+                self.ancestor_bundle_mut().$method(builder);
+                self
+            }
+        }
+    };
+}
+
+impl_builder_setters! {
+    @fallible
+    trait = TrySetMandatoryBuilder,
+    method = try_set_mandatory_builder,
+    index = MandatorySameAsIndex,
+    bundle_trait = TrySetMandatoryBuilder,
+    descendant = [DescendantOf<
+        Key::Table,
+        NestedPrimaryKeyColumns: NestedColumns<
+            NestedTupleColumnType = (<<Key::Table as Table>::PrimaryKey as ColumnTyped>::ColumnType,),
         >,
-    Key: MandatorySameAsIndex,
-    Key::Table: AncestorOfIndex<T> + BuildableTable,
-    Key::ReferencedTable: BuildableTable,
-    Self: TryMaySetNestedColumns<T::Error, Key::NestedHostColumns>
-        + MayValidateNestedColumns<T::Error, Key::NestedHostColumns>
-        + AncestorBundleMut<Key::Table>,
-    TableBuilder<Key::ReferencedTable>: MayGetNestedColumns<Key::NestedForeignColumns>,
-    TableBuilderBundle<Key::Table>: TrySetMandatoryBuilder<Key, Table = Key::Table>,
-    T::Error: From<<Key::Table as TableExt>::Error>,
-{
-    #[inline]
-    fn try_set_mandatory_builder(
-        &mut self,
-        builder: TableBuilder<<Key as ForeignPrimaryKey>::ReferencedTable>,
-    ) -> Result<&mut Self, T::Error> {
-        let columns = builder.may_get_nested_columns();
-        let converted_columns = columns.nested_tuple_option_into();
-        self.may_validate_nested_columns(&converted_columns)?;
-        self.ancestor_bundle_mut().try_set_mandatory_builder(builder)?;
-        self.try_may_set_nested_columns(converted_columns)?;
-        Ok(self)
-    }
+    >],
 }
 
-impl<C, T> SetMandatoryBuilder<C> for TableBuilder<T>
-where
-    T: BuildableTable + DescendantOf<C::Table>,
-    C: MandatorySameAsIndex,
-    C::Table: AncestorOfIndex<T> + BuildableTable,
-    C::ReferencedTable: BuildableTable,
-    Self: MaySetColumns<C::NestedHostColumns> + AncestorBundleMut<C::Table>,
-    TableBuilderBundle<C::Table>: SetMandatoryBuilder<C>,
-    TableBuilder<<C as ForeignPrimaryKey>::ReferencedTable>:
-        MayGetNestedColumns<C::NestedForeignColumns>,
-{
-    #[inline]
-    fn set_mandatory_builder(
-        &mut self,
-        builder: TableBuilder<<C as ForeignPrimaryKey>::ReferencedTable>,
-    ) -> &mut Self {
-        let columns = builder.may_get_nested_columns();
-        let converted_columns = columns.nested_tuple_option_into();
-        self.may_set_nested_columns(converted_columns);
-        self.ancestor_bundle_mut().set_mandatory_builder(builder);
-        self
-    }
+impl_builder_setters! {
+    @fallible
+    trait = TrySetDiscretionaryBuilder,
+    method = try_set_discretionary_builder,
+    index = DiscretionarySameAsIndex,
+    bundle_trait = TrySetDiscretionaryBuilder,
+    descendant = [DescendantOf<Key::Table>],
 }
 
-impl<Key, T> TrySetDiscretionaryBuilder<Key> for TableBuilder<T>
-where
-    T: BuildableTable + DescendantOf<Key::Table>,
-    Key: DiscretionarySameAsIndex,
-    Key::Table: AncestorOfIndex<T> + BuildableTable,
-    Key::ReferencedTable: BuildableTable,
-    Self: TryMaySetNestedColumns<T::Error, Key::NestedHostColumns>
-        + MayValidateNestedColumns<T::Error, Key::NestedHostColumns>
-        + AncestorBundleMut<Key::Table>,
-    TableBuilder<Key::ReferencedTable>: MayGetNestedColumns<Key::NestedForeignColumns>,
-    TableBuilderBundle<Key::Table>: TrySetDiscretionaryBuilder<Key, Table = Key::Table>,
-    T::Error: From<<Key::Table as TableExt>::Error>,
-{
-    #[inline]
-    fn try_set_discretionary_builder(
-        &mut self,
-        builder: TableBuilder<<Key as ForeignPrimaryKey>::ReferencedTable>,
-    ) -> Result<&mut Self, T::Error> {
-        let columns = builder.may_get_nested_columns();
-        let converted_columns = columns.nested_tuple_option_into();
-        self.may_validate_nested_columns(&converted_columns)?;
-        self.ancestor_bundle_mut().try_set_discretionary_builder(builder)?;
-        self.try_may_set_nested_columns(converted_columns)?;
-        Ok(self)
-    }
+impl_builder_setters! {
+    @infallible
+    trait = SetMandatoryBuilder,
+    method = set_mandatory_builder,
+    index = MandatorySameAsIndex,
+    bundle_trait = SetMandatoryBuilder,
 }
 
-impl<C, T> SetDiscretionaryBuilder<C> for TableBuilder<T>
-where
-    T: BuildableTable + DescendantOf<C::Table>,
-    C: DiscretionarySameAsIndex,
-    C::Table: AncestorOfIndex<T> + BuildableTable,
-    C::ReferencedTable: BuildableTable,
-    Self: MaySetColumns<C::NestedHostColumns> + AncestorBundleMut<C::Table>,
-    TableBuilder<C::ReferencedTable>: MayGetNestedColumns<C::NestedForeignColumns>,
-    TableBuilderBundle<C::Table>: SetDiscretionaryBuilder<C>,
-{
-    #[inline]
-    fn set_discretionary_builder(
-        &mut self,
-        builder: TableBuilder<<C as ForeignPrimaryKey>::ReferencedTable>,
-    ) -> &mut Self {
-        let columns = builder.may_get_nested_columns();
-        let converted_columns = columns.nested_tuple_option_into();
-        self.may_set_nested_columns(converted_columns);
-        self.ancestor_bundle_mut().set_discretionary_builder(builder);
-        self
-    }
+impl_builder_setters! {
+    @infallible
+    trait = SetDiscretionaryBuilder,
+    method = set_discretionary_builder,
+    index = DiscretionarySameAsIndex,
+    bundle_trait = SetDiscretionaryBuilder,
 }


### PR DESCRIPTION
Four sets of impls in the core crate were byte-identical, or identical modulo one marker, across separate copies, so a change to any one of them had to be mirrored by hand. Each is now emitted from a small macro in the established style of the crate's existing `impl_same_as_nested_columns!` and `set_builder_ext!`.

The `GetColumn` forwarding impls for `&T`, `Box<T>`, `Rc<T>`, and `Arc<T>` share one macro that delegates through `(**self)`, which reaches the inner `T` uniformly for every wrapper. The two `TrySetColumn` leaf impls for the `NewValues` tuple arities share one body. The four `TableBuilder<T>` triangular builder-setter impls come from a macro with a fallible and an infallible arm, parameterised by the key marker, the delegated bundle trait, the method name, and the extra single-column primary key bound that only the fallible mandatory case carries. Finally the four impls shared verbatim by `TableBuilderBundle` and `CompletedTableBuilderBundle`, namely `HasTable`, `ValidateColumn`, `TrySetColumn`, and the discretionary same-as setter, are emitted by one macro invoked once per struct, with the genuinely different mandatory same-as setter left per struct.

Every generated impl keeps the same signature it had before, so this is a pure deduplication. Build, clippy, the documentation build, and the full test suite pass.

## Summary by Sourcery

Enhancements:
- Consolidate duplicated core trait implementations into reusable macros while preserving all existing generated interfaces and behavior.