### PR TITLE
Share the derive crate's type-parsing and index-emitting helpers

### DIFF
--- a/diesel-builders-derive/src/lib.rs
+++ b/diesel-builders-derive/src/lib.rs
@@ -51,18 +51,8 @@ impl syn::parse::Parse for IndexDefinition {
 /// index.
 fn generate_index_impl(input: TokenStream, trait_path: &proc_macro2::TokenStream) -> TokenStream {
     let index_def = syn::parse_macro_input!(input as IndexDefinition);
-    let cols: Vec<_> = index_def.columns.iter().collect();
-
-    let impls = cols.iter().enumerate().map(|(idx, col)| {
-        let idx_type = crate::utils::typenum_ident(idx);
-        quote::quote! {
-            impl #trait_path<
-                diesel_builders::typenum::#idx_type,
-                ( #(#cols,)* )
-            > for #col {}
-        }
-    });
-
+    let columns: Vec<_> = index_def.columns.iter().map(|col| quote::quote! { #col }).collect();
+    let impls = crate::utils::index_impls(trait_path, &columns);
     quote::quote! {
         #(#impls)*
     }

--- a/diesel-builders-derive/src/table_model/attribute_parsing.rs
+++ b/diesel-builders-derive/src/table_model/attribute_parsing.rs
@@ -278,14 +278,6 @@ pub fn extract_field_default_value(field: &syn::Field) -> Option<syn::Expr> {
         });
     }
 
-    if default_values.len() > 1 {
-        // We can't easily return an error here because the signature returns
-        // Option<Expr>. But we can panic or log. Ideally we should
-        // change the signature or handle it in validation.
-        // For now, let's just return the first one, and we'll add a separate
-        // validation function.
-    }
-
     default_values.into_iter().next()
 }
 

--- a/diesel-builders-derive/src/table_model/foreign_keys.rs
+++ b/diesel-builders-derive/src/table_model/foreign_keys.rs
@@ -621,20 +621,7 @@ fn generate_impls_for_groups<'b>(
         // target same index, implies they have compatible types.
         let mut base_types = Vec::new();
         for field in &first_key.host_fields {
-            let ty = &field.ty;
-            let inner_ty = if crate::utils::is_option(ty) {
-                if let syn::Type::Path(type_path) = ty
-                    && let Some(segment) = type_path.path.segments.last()
-                    && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
-                    && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
-                {
-                    inner
-                } else {
-                    ty // Fallback, shouldn't happen if is_option checks out
-                }
-            } else {
-                ty
-            };
+            let inner_ty = crate::utils::option_inner_type(&field.ty).unwrap_or(&field.ty);
             base_types.push(quote!(#inner_ty));
         }
 

--- a/diesel-builders-derive/src/table_model/primary_key.rs
+++ b/diesel-builders-derive/src/table_model/primary_key.rs
@@ -9,20 +9,7 @@ pub fn generate_indexed_column_impls(
     table_module: &syn::Ident,
     primary_key_columns: &[Ident],
 ) -> Vec<TokenStream> {
-    let pk_column_types: Vec<_> =
+    let columns: Vec<_> =
         primary_key_columns.iter().map(|col| quote! { #table_module::#col }).collect();
-
-    primary_key_columns
-        .iter()
-        .enumerate()
-        .map(|(idx, col)| {
-            let idx_type = crate::utils::typenum_ident(idx);
-            quote! {
-                impl ::diesel_builders::UniquelyIndexedColumn<
-                    ::diesel_builders::typenum::#idx_type,
-                    ( #(#pk_column_types,)* )
-                > for #table_module::#col {}
-            }
-        })
-        .collect()
+    crate::utils::index_impls(&quote! { ::diesel_builders::UniquelyIndexedColumn }, &columns)
 }

--- a/diesel-builders-derive/src/table_model/table_generation.rs
+++ b/diesel-builders-derive/src/table_model/table_generation.rs
@@ -5,19 +5,10 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{DeriveInput, Field, Ident, Type};
 
-use crate::{table_model::attribute_parsing::extract_sql_name, utils::is_option};
-
-/// Extracts the first generic type argument from a type path, if it exists.
-fn extract_first_generic_arg(ty: &Type) -> Option<&Type> {
-    if let Type::Path(type_path) = ty
-        && let syn::PathArguments::AngleBracketed(args) = &type_path.path.segments.last()?.arguments
-        && let syn::GenericArgument::Type(inner_ty) = args.args.first()?
-    {
-        Some(inner_ty)
-    } else {
-        None
-    }
-}
+use crate::{
+    table_model::attribute_parsing::extract_sql_name,
+    utils::{first_generic_arg, is_option},
+};
 
 /// Maps primitive Rust types to their corresponding Diesel SQL types.
 fn map_primitive_type(type_name: &str) -> Option<TokenStream> {
@@ -41,7 +32,7 @@ fn map_primitive_type(type_name: &str) -> Option<TokenStream> {
 fn infer_sql_type(ty: &Type) -> Option<TokenStream> {
     // Handle Option<T> -> Nullable<InnerType>
     if is_option(ty) {
-        let inner_ty = extract_first_generic_arg(ty)?;
+        let inner_ty = first_generic_arg(ty)?;
         let inner_sql_type = infer_sql_type(inner_ty)?;
         return Some(quote! { diesel::sql_types::Nullable<#inner_sql_type> });
     }
@@ -53,7 +44,7 @@ fn infer_sql_type(ty: &Type) -> Option<TokenStream> {
 
         // Handle Vec<T>
         if type_name == "Vec" {
-            let inner_ty = extract_first_generic_arg(ty)?;
+            let inner_ty = first_generic_arg(ty)?;
 
             // Special case: Vec<u8> -> Binary
             if let Type::Path(inner_path) = inner_ty

--- a/diesel-builders-derive/src/table_model/typed_column.rs
+++ b/diesel-builders-derive/src/table_model/typed_column.rs
@@ -285,24 +285,7 @@ fn generate_typed_impl(
 
 /// Extract the inner type from `Option<T>`, returning `None` if not an Option.
 fn extract_option_inner_type(field_type: &syn::Type) -> Option<TokenStream> {
-    let syn::Type::Path(type_path) = field_type else {
-        return None;
-    };
-
-    let segment = type_path.path.segments.last()?;
-    if segment.ident != "Option" {
-        return None;
-    }
-
-    let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
-        return None;
-    };
-
-    let syn::GenericArgument::Type(inner) = args.args.first()? else {
-        return None;
-    };
-
-    Some(quote::quote! { #inner })
+    crate::utils::option_inner_type(field_type).map(|inner| quote::quote! { #inner })
 }
 
 /// Method identifiers for a triangular relation field, derived from whether the

--- a/diesel-builders-derive/src/utils.rs
+++ b/diesel-builders-derive/src/utils.rs
@@ -70,6 +70,51 @@ pub(crate) fn is_option(ty: &syn::Type) -> bool {
     false
 }
 
+/// Returns the first generic type argument of a type path, such as the `T` in
+/// `Foo<T, ..>`, or `None` when the type has no angle-bracketed type argument.
+pub(crate) fn first_generic_arg(ty: &syn::Type) -> Option<&syn::Type> {
+    let syn::Type::Path(type_path) = ty else {
+        return None;
+    };
+    let syn::PathArguments::AngleBracketed(args) = &type_path.path.segments.last()?.arguments
+    else {
+        return None;
+    };
+    match args.args.first()? {
+        syn::GenericArgument::Type(inner) => Some(inner),
+        _ => None,
+    }
+}
+
+/// Returns the inner type `T` of an `Option<T>`, or `None` for any other type.
+pub(crate) fn option_inner_type(ty: &syn::Type) -> Option<&syn::Type> {
+    is_option(ty).then(|| first_generic_arg(ty)).flatten()
+}
+
+/// Emits an index-marker `impl` for every column of an index.
+///
+/// Each column `col` at position `idx` gets
+/// `impl #trait_path<typenum::U{idx}, ( #columns, )> for col {}`, shared by the
+/// primary-key codegen and the `index!` / `unique_index!` proc macros.
+pub(crate) fn index_impls(
+    trait_path: &proc_macro2::TokenStream,
+    columns: &[proc_macro2::TokenStream],
+) -> Vec<proc_macro2::TokenStream> {
+    columns
+        .iter()
+        .enumerate()
+        .map(|(idx, col)| {
+            let idx_type = typenum_ident(idx);
+            quote::quote! {
+                impl #trait_path<
+                    ::diesel_builders::typenum::#idx_type,
+                    ( #(#columns,)* )
+                > for #col {}
+            }
+        })
+        .collect()
+}
+
 /// Convert a `CamelCase` string to `snake_case`.
 pub(crate) fn camel_to_snake_case(s: &str) -> String {
     let mut result = String::new();


### PR DESCRIPTION
Three small pieces of the derive crate repeated the same logic, so each now lives in one place.

The parse for the first angle-bracketed type argument existed in three forms, a private helper in `table_generation`, `extract_option_inner_type` in `typed_column`, and an inline block in `foreign_keys`. It is now one `utils::first_generic_arg` together with an `Option`-specific `utils::option_inner_type` built on top of it, and the three sites call those. The `extract_field_default_value` parser carried an empty `if` whose only content was a comment saying the duplicate-default check ought to live in a separate validation function, which it already does in `validate_field_attributes`, so the dead block is removed. Finally the primary-key codegen and the `index!` and `unique_index!` proc macros emitted the same `typenum`-indexed marker impl, so both now call one `utils::index_impls`.

Generated output is unchanged apart from a leading path colon on the index impls that resolves identically. Build, clippy, the documentation build, the full test suite, and the nightly trybuild all pass.

## Summary by Sourcery

Consolidate repeated derive-crate type parsing and index code generation while preserving generated behavior.

Enhancements:
- Centralize generic type parsing and index-marker implementation generation in shared derive utilities.
- Remove an obsolete empty default-value validation block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Repeated type parsing and index implementation generation lacked shared helpers, which increased duplication across derive code and macros. The fix centralizes these operations in `utils` and reuses them across primary key, foreign key, typed column, and table generation code.

The unused default validation block was removed because duplicate validation already occurs in `validate_field_attributes`. Generated behavior remains unchanged, apart from an equivalent leading path colon in index implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->