### PR TITLE
Remove dead code and tidy clarity in the core crate

### DIFF
--- a/diesel-builders/src/builder_error.rs
+++ b/diesel-builders/src/builder_error.rs
@@ -145,3 +145,33 @@ impl<E: DatabaseErrorInformation + Send + Sync + 'static> From<BuilderError<E>>
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{BuilderError, IncompleteBuilderError};
+
+    fn missing_field() -> IncompleteBuilderError {
+        IncompleteBuilderError::MissingMandatoryField { table_name: "t", field_name: "f" }
+    }
+
+    #[test]
+    fn builder_error_converts_to_diesel_error() {
+        let passthrough: diesel::result::Error =
+            BuilderError::<IncompleteBuilderError>::Diesel(diesel::result::Error::NotFound).into();
+        assert!(matches!(passthrough, diesel::result::Error::NotFound));
+
+        for error in [
+            BuilderError::<IncompleteBuilderError>::Incomplete(missing_field()),
+            BuilderError::<IncompleteBuilderError>::Validation(missing_field()),
+        ] {
+            let converted: diesel::result::Error = error.into();
+            assert!(matches!(
+                converted,
+                diesel::result::Error::DatabaseError(
+                    diesel::result::DatabaseErrorKind::CheckViolation,
+                    _,
+                )
+            ));
+        }
+    }
+}

--- a/diesel-builders/src/builder_error.rs
+++ b/diesel-builders/src/builder_error.rs
@@ -132,20 +132,16 @@ impl<E: DatabaseErrorInformation + Send + Sync + 'static> From<BuilderError<E>>
     for diesel::result::Error
 {
     fn from(error: BuilderError<E>) -> Self {
+        let check_violation = |info: Box<dyn DatabaseErrorInformation + Send + Sync>| {
+            diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::CheckViolation,
+                info,
+            )
+        };
         match error {
             BuilderError::Diesel(e) => e,
-            BuilderError::Incomplete(e) => {
-                diesel::result::Error::DatabaseError(
-                    diesel::result::DatabaseErrorKind::CheckViolation,
-                    Box::new(e),
-                )
-            }
-            BuilderError::Validation(e) => {
-                diesel::result::Error::DatabaseError(
-                    diesel::result::DatabaseErrorKind::CheckViolation,
-                    Box::new(e),
-                )
-            }
+            BuilderError::Incomplete(e) => check_violation(Box::new(e)),
+            BuilderError::Validation(e) => check_violation(Box::new(e)),
         }
     }
 }

--- a/diesel-builders/src/columns.rs
+++ b/diesel-builders/src/columns.rs
@@ -22,15 +22,11 @@ use tuplities::prelude::*;
 use crate::TypedNestedTuple;
 
 /// A trait representing a collection of Diesel columns.
-pub trait Columns: NestTuple<Nested: Default + TypedNestedTuple> {
-    /// Tables to which these columns belong.
-    type Tables: NestTuple;
-}
+pub trait Columns: NestTuple<Nested: Default + TypedNestedTuple> {}
 
 impl<T> Columns for T
 where
     T: NestTuple<Nested: NestedColumns>,
     <<T::Nested as NestedColumns>::NestedTables as FlattenNestedTuple>::Flattened: NestTuple,
 {
-    type Tables = <<T::Nested as NestedColumns>::NestedTables as FlattenNestedTuple>::Flattened;
 }

--- a/diesel-builders/src/columns/columns_collection.rs
+++ b/diesel-builders/src/columns/columns_collection.rs
@@ -4,7 +4,8 @@ use tuplities::prelude::*;
 
 use super::NestedColumnsCollection;
 
-/// A trait representing a collection of Diesel columns.
+/// A trait representing a matrix (a collection of collections) of Diesel
+/// columns.
 pub trait ColumnsCollection: NestTupleMatrix {}
 
 impl<C> ColumnsCollection for C where

--- a/diesel-builders/src/foreign_key/iter_foreign_key/blankets.rs
+++ b/diesel-builders/src/foreign_key/iter_foreign_key/blankets.rs
@@ -1,9 +1,8 @@
 //! Blanket implementations of `IterForeignKey` for tuples.
 
-use tuplities::prelude::{IntoNestedTupleOption, NestedTupleRef};
-
+use super::OptRef;
 use crate::{
-    IterDynForeignKeys, IterForeignKeys, TryGetDynamicColumns, TypedNestedTuple,
+    IterDynForeignKeys, IterForeignKeys, TryGetDynamicColumns,
     columns::{HasNestedDynColumns, NestedDynColumns, NonEmptyNestedProjection},
 };
 
@@ -16,14 +15,10 @@ where
         std::iter::empty()
     }
 
-    fn iter_match_simple<'a>(
-        &'a self,
-    ) -> impl Iterator<
-        Item = <<<NestedIdx as TypedNestedTuple>::NestedTupleValueType as NestedTupleRef>::Ref<'a> as IntoNestedTupleOption>::IntoOptions,
-    >
+    fn iter_match_simple<'a>(&'a self) -> impl Iterator<Item = OptRef<'a, NestedIdx>>
     where
         NestedIdx: 'a,
-{
+    {
         std::iter::empty()
     }
 }
@@ -38,14 +33,10 @@ where
         T::iter_foreign_key_columns()
     }
 
-    fn iter_match_simple<'a>(
-        &'a self,
-    ) -> impl Iterator<
-        Item = <<<NestedIdx as TypedNestedTuple>::NestedTupleValueType as NestedTupleRef>::Ref<'a> as IntoNestedTupleOption>::IntoOptions,
-    >
+    fn iter_match_simple<'a>(&'a self) -> impl Iterator<Item = OptRef<'a, NestedIdx>>
     where
         NestedIdx: 'a,
-{
+    {
         self.0.iter_match_simple()
     }
 }
@@ -61,14 +52,10 @@ where
         Head::iter_foreign_key_columns().chain(Tail::iter_foreign_key_columns())
     }
 
-    fn iter_match_simple<'a>(
-        &'a self,
-    ) -> impl Iterator<
-        Item = <<<NestedIdx as TypedNestedTuple>::NestedTupleValueType as NestedTupleRef>::Ref<'a> as IntoNestedTupleOption>::IntoOptions,
-    >
+    fn iter_match_simple<'a>(&'a self) -> impl Iterator<Item = OptRef<'a, NestedIdx>>
     where
         NestedIdx: 'a,
-{
+    {
         self.0.iter_match_simple().chain(self.1.iter_match_simple())
     }
 }

--- a/diesel-builders/src/lib.rs
+++ b/diesel-builders/src/lib.rs
@@ -121,8 +121,7 @@ pub mod prelude {
     // Note: Root is NOT exported here to avoid collision with Root macro from
     // diesel_builders_derive
     pub use crate::horizontal_same_as::HorizontalKey;
-    // Builder setter extension traits (always use Ext variants)
-    /// Query loading traits
+    // Query loading traits
     pub use crate::load_query_builder::{LoadFirst, LoadMany, LoadSorted};
     pub use crate::{
         builder_bundle::BundlableTable,

--- a/diesel-builders/src/typed.rs
+++ b/diesel-builders/src/typed.rs
@@ -60,19 +60,3 @@ impl<T> OptionalRef<T> for Option<T> {
         self.as_ref()
     }
 }
-
-/// Trait representing an object whose `ValueType` and `ColumnType` are the
-/// same, and therefore cannot be optional.
-///
-/// Extends [`ColumnTyped`].
-pub trait NonOptionalTyped: ColumnTyped<ValueType = <Self as ColumnTyped>::ColumnType> {}
-
-impl<T> NonOptionalTyped for T where T: ColumnTyped<ValueType = <T as ColumnTyped>::ColumnType> {}
-
-/// Trait representing an object whose `ColumnType` is an `Option` of its
-/// `ValueType`.
-///
-/// Extends [`ColumnTyped`].
-pub trait OptionalTyped: ColumnTyped<ColumnType = Option<<Self as ValueTyped>::ValueType>> {}
-
-impl<T> OptionalTyped for T where T: ColumnTyped<ColumnType = Option<<T as ValueTyped>::ValueType>> {}


### PR DESCRIPTION
This is dead code removal plus a few small clarity fixes, no behaviour change.

`NonOptionalTyped` and `OptionalTyped` were public marker traits with no consumers anywhere, the actually-used sibling being the differently named `NonOptionalTypedNestedTuple`, and `Columns::Tables` was an associated type that no code ever read, so all three are removed. The three `iter_match_simple` blanket impls re-spelled the long optional-reference projection that the module already names `OptRef<'a, T>` and that the trait definition itself uses, so they now reuse the alias. The `From<BuilderError<E>>` conversion built the same `CheckViolation` error in two match arms, now shared through a small closure. A prelude comment mislabelled the query-loading re-export as builder setters and carried a stray doc comment, both corrected, and a doc line duplicated verbatim between `Columns` and `ColumnsCollection` is reworded.

Build, clippy, the documentation build, and the full test suite pass.

## Summary by Sourcery

Clean up unused core APIs and improve code clarity without changing behavior.

Enhancements:
- Remove unused public marker traits and the unused `Columns::Tables` associated type.
- Simplify repeated type signatures by reusing the existing optional-reference alias and consolidate builder error conversion logic.
- Improve core crate documentation and prelude comments for clarity.

Tests:
- Add coverage for converting builder errors to the corresponding Diesel errors.