### PR TITLE
Emit a uniform absolute path from the index proc macros

### DIFF
--- a/diesel-builders-derive/src/lib.rs
+++ b/diesel-builders-derive/src/lib.rs
@@ -65,7 +65,7 @@ fn generate_index_impl(input: TokenStream, trait_path: &proc_macro2::TokenStream
 /// in the index.
 #[proc_macro]
 pub fn unique_index(input: TokenStream) -> TokenStream {
-    generate_index_impl(input, &quote::quote!(diesel_builders::UniquelyIndexedColumn))
+    generate_index_impl(input, &quote::quote!(::diesel_builders::UniquelyIndexedColumn))
 }
 
 /// Define a table index using SQL-like syntax.
@@ -74,5 +74,5 @@ pub fn unique_index(input: TokenStream) -> TokenStream {
 /// index.
 #[proc_macro]
 pub fn index(input: TokenStream) -> TokenStream {
-    generate_index_impl(input, &quote::quote!(diesel_builders::IndexedColumn))
+    generate_index_impl(input, &quote::quote!(::diesel_builders::IndexedColumn))
 }


### PR DESCRIPTION
A tiny consistency fix in the generated code, no behaviour change.

The `index!` and `unique_index!` proc macros passed their marker trait as `diesel_builders::UniquelyIndexedColumn` while the shared `utils::index_impls` emits the `typenum` argument as `::diesel_builders::typenum::...`, so a single generated impl mixed the leading-colon and bare path styles. Both resolve to the same crate, and passing the trait as `::diesel_builders::...` makes every emitted impl use one absolute path, matching the primary-key codegen.

This is the first of the two minor observations from the maintainer review of the recent cleanup PRs. The second, fully qualifying the cross-file bundle macro so it no longer relies on call-site imports, is intentionally left alone, since the compiler already errors if a needed import is dropped and full qualification would make that macro markedly more verbose than the crate's other bare-name macros.

Build, clippy, the full test suite, and the nightly trybuild pass.

## Summary by Sourcery

Enhancements:
- Use consistent absolute crate paths in code generated by the `index!` and `unique_index!` procedural macros.